### PR TITLE
Add new AWS types

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 boto3>=1.9.93
-PyYAML>=3.12
+ruamel.yaml
 valley>=1.5.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 boto3>=1.9.93
 ruamel.yaml
-valley>=1.5.2
+valley==1.5.6

--- a/sammy/__init__.py
+++ b/sammy/__init__.py
@@ -451,6 +451,17 @@ class API(Resource):
     CacheClusterSize = CharForeignProperty(Ref)
     Variables = DictProperty()
 
+class DomainValidationOptions(SAMSchema):
+    DomainName = CharForeignProperty(Ref, required=False)
+    HostedZoneId = CharForeignProperty(Ref, required=False)
+
+class CertificateManagerCertificate(Resource):
+    _resource_type = "AWS::CertificateManager::Certificate"
+    _serverless_type = True
+
+    DomainName = CharForeignProperty(Ref, required=False)
+    ValidationMethod = CharForeignProperty(Ref, required=False)
+    DomainValidationOptions = ForeignInstanceListProperty(DomainValidationOptions, required=False)
 
 class HttpApiDomainConfiguration(SAMSchema):
     DomainName = CharForeignProperty(Ref, required=False)

--- a/sammy/__init__.py
+++ b/sammy/__init__.py
@@ -57,6 +57,14 @@ class Ref(SAMSchema):
     Ref = CharProperty(required=True)
 
 
+class GetAtt(SAMSchema):
+    GetAtt = CharProperty(required=True)
+
+    def to_dict(self):
+        ga = self._data.copy().get('GetAtt')
+        return f'!GetAtt {ga}'
+
+
 class Sub(SAMSchema):
     Sub = CharForeignProperty(Ref, required=True)
     Map = DictProperty()
@@ -336,8 +344,11 @@ class Function(AbstractFunction):
     _resource_type = 'AWS::Serverless::Function'
     _serverless_type = True
 
-    CodeUri = ForeignProperty(S3URI)
-    Policies = CharForeignProperty(Ref)
+    # Needs to be string | ForeignProperty(S3URI)
+    # but no union type in valley as far as I can see
+    CodeUri = CharForeignProperty(Ref)
+
+    Policies = ListProperty(Ref)
     Events = ForeignInstanceListProperty(EventSchema)
     Tracing = CharForeignProperty(Ref)
     DeadLetterQueue = ForeignInstanceListProperty(DeadLetterQueueSchema)

--- a/sammy/__init__.py
+++ b/sammy/__init__.py
@@ -454,6 +454,21 @@ class CloudFrontOriginAccessIdentity(Resource):
     CloudFrontOriginAccessIdentityConfig = DictProperty(required=False)
 
 
+class S3Bucket(Resource):
+    _resource_type = "AWS::S3::Bucket"
+    _serverless_type = True
+
+    BucketName = CharForeignProperty(Ref, required=False)
+
+
+class S3BucketPolicy(Resource):
+    _resource_type = "AWS::S3::BucketPolicy"
+    _serverless_type = True
+
+    Bucket = CharForeignProperty(Ref, required=False)
+    PolicyDocument = DictProperty(required=False)
+
+
 class CloudfrontDistribution(Resource):
     _resource_type = "AWS::CloudFront::Distribution"
     _serverless_type = True

--- a/sammy/__init__.py
+++ b/sammy/__init__.py
@@ -446,7 +446,19 @@ class HttpAPI(Resource):
 
     Domain = ForeignProperty(HttpApiDomainConfiguration, required=False)
 
-    #Properties = DictProperty(name="Properties")
+
+class CloudFrontOriginAccessIdentity(Resource):
+    _resource_type = "AWS::CloudFront::CloudFrontOriginAccessIdentity"
+    _serverless_type = True
+
+    CloudFrontOriginAccessIdentityConfig = DictProperty(required=False)
+
+
+class CloudfrontDistribution(Resource):
+    _resource_type = "AWS::CloudFront::Distribution"
+    _serverless_type = True
+
+    DistributionConfig = DictProperty(required=False)
 
 
 class SimpleTable(Resource):

--- a/sammy/__init__.py
+++ b/sammy/__init__.py
@@ -818,3 +818,22 @@ class CFT(SAM):
             if len(outputs.keys()) > 0:
                 template['Outputs'] = outputs
         return template
+
+class SNSTopic(Resource):
+    _resource_type = "AWS::SNS::Topic"
+    _serverless_type = True
+
+    Subscription = ListProperty(required=True)
+
+
+class CloudWatchAlarm(Resource):
+    _resource_type = "AWS::CloudWatch::Alarm"
+    _serverless_type = True
+
+    AlarmDescription = CharProperty()
+    AlarmActions = ListProperty()
+    Metrics = ListProperty()
+    ComparisonOperator = CharProperty()
+    Threshold = CharProperty()
+    EvaluationPeriods = CharProperty()
+    TreatMissingData = CharProperty()

--- a/sammy/__init__.py
+++ b/sammy/__init__.py
@@ -267,12 +267,6 @@ class SQSEvent(EventSchema):
     MaximumBatchingWindowInSeconds = IntegerProperty()
 
 
-class ScheduleEvent(EventSchema):
-    _event_type = 'Schedule'
-
-    Schedule = CharProperty()
-
-
 class KinesisEvent(EventSchema):
     _event_type = 'Kinesis'
 
@@ -290,6 +284,8 @@ class DynamoDBEvent(EventSchema):
 
 
 class ScheduleEvent(EventSchema):
+    _event_type = 'Schedule'
+
     Schedule = CharForeignProperty(Ref, required=True)
     Input = CharForeignProperty(Ref)
 

--- a/sammy/__init__.py
+++ b/sammy/__init__.py
@@ -838,6 +838,7 @@ class CloudWatchAlarm(Resource):
     Threshold = CharProperty()
     Namespace = CharProperty()
     MetricName = CharProperty()
+    Period = CharProperty()
     Statistic = CharProperty()
     Dimensions = ListProperty()
     DatapointsToAlarm = CharProperty()

--- a/sammy/__init__.py
+++ b/sammy/__init__.py
@@ -187,7 +187,7 @@ class EventSchema(SAMSchema):
 class StateSchema(SAMSchema):
     name = CharForeignProperty(Ref, required=True)
     Type = CharForeignProperty(Ref, required=False)
-    Seconds = CharForeignProperty(Ref, required=False)
+    Seconds = IntForeignProperty(Ref, required=False)
     Next = CharForeignProperty(Ref, required=False)
     Resource = CharForeignProperty(Ref, required=False)
     End = BooleanProperty(required=False)

--- a/sammy/__init__.py
+++ b/sammy/__init__.py
@@ -453,12 +453,20 @@ class HttpApiDomainConfiguration(SAMSchema):
     DomainName = CharForeignProperty(Ref, required=False)
     CertificateArn = CharForeignProperty(Ref, required=False)
 
+class HttpApiCorsConfiguration(SAMSchema):
+    AllowCredentials = BooleanProperty(required=False)
+    AllowHeaders = ListProperty(required=False)
+    AllowMethods = ListProperty(required=False)
+    AllowOrigins = ListProperty(required=False)
+    ExposeHeaders = ListProperty(required=False)
+    MaxAge = IntegerProperty()
 
 class HttpAPI(Resource):
     _resource_type = "AWS::Serverless::HttpApi"
     _serverless_type = True
 
     Domain = ForeignProperty(HttpApiDomainConfiguration, required=False)
+    CorsConfiguration = ForeignProperty(HttpApiCorsConfiguration, required=False)
     AccessLogSettings = DictProperty(required=False)
 
 

--- a/sammy/__init__.py
+++ b/sammy/__init__.py
@@ -152,11 +152,19 @@ class Resource(SAMSchema):
         obj = remove_nulls(self._data.copy())
         name = obj.pop('name')
 
+        metadata = None
+        if 'Metadata' in obj:
+            metadata = obj.pop('Metadata')
+
         r_attrs = {
             'Type': self._resource_type
         }
         if len(obj.keys()) > 0:
             r_attrs['Properties'] = {k: v for k, v in obj.items() if v}
+
+        if metadata is not None:
+            r_attrs['Metadata'] = metadata
+
         return {
             'name': name,
             'r': r_attrs
@@ -403,6 +411,7 @@ class Function(AbstractFunction):
     Tracing = CharForeignProperty(Ref)
     DeadLetterQueue = ForeignInstanceListProperty(DeadLetterQueueSchema)
     ReservedConcurrentExecutions = IntegerProperty()
+    Layers = ListProperty()
 
 
 class CFunction(AbstractFunction):
@@ -452,6 +461,15 @@ class CloudFrontOriginAccessIdentity(Resource):
     _serverless_type = True
 
     CloudFrontOriginAccessIdentityConfig = DictProperty(required=False)
+
+
+class LayerVersion(Resource):
+    _resource_type = "AWS::Serverless::LayerVersion"
+    _serverless_type = True
+
+    ContentUri = CharForeignProperty(Ref, required=False)
+    CompatibleRuntimes = ListProperty()
+    Metadata = DictProperty()
 
 
 class S3Bucket(Resource):

--- a/sammy/__init__.py
+++ b/sammy/__init__.py
@@ -454,6 +454,7 @@ class HttpAPI(Resource):
     _serverless_type = True
 
     Domain = ForeignProperty(HttpApiDomainConfiguration, required=False)
+    AccessLogSettings = DictProperty(required=False)
 
 
 class CloudFrontOriginAccessIdentity(Resource):
@@ -835,5 +836,16 @@ class CloudWatchAlarm(Resource):
     Metrics = ListProperty()
     ComparisonOperator = CharProperty()
     Threshold = CharProperty()
+    Namespace = CharProperty()
+    MetricName = CharProperty()
+    Statistic = CharProperty()
+    Dimensions = ListProperty()
+    DatapointsToAlarm = CharProperty()
     EvaluationPeriods = CharProperty()
     TreatMissingData = CharProperty()
+
+
+class AccessLogGroup(Resource):
+    _resource_type = "AWS::Logs::LogGroup"
+    _serverless_type = True
+

--- a/sammy/__init__.py
+++ b/sammy/__init__.py
@@ -264,6 +264,7 @@ class SQSEvent(EventSchema):
     Queue = CharForeignProperty(Ref, required=True)
     BatchSize = IntForeignProperty(Ref)
     FunctionResponseTypes = ListProperty()
+    MaximumBatchingWindowInSeconds = IntegerProperty()
 
 
 class KinesisEvent(EventSchema):

--- a/sammy/__init__.py
+++ b/sammy/__init__.py
@@ -466,6 +466,7 @@ class CertificateManagerCertificate(Resource):
 class HttpApiDomainConfiguration(SAMSchema):
     DomainName = CharForeignProperty(Ref, required=False)
     CertificateArn = CharForeignProperty(Ref, required=False)
+    Route53 = DictProperty()
 
 class HttpApiCorsConfiguration(SAMSchema):
     AllowCredentials = BooleanProperty(required=False)

--- a/sammy/__init__.py
+++ b/sammy/__init__.py
@@ -200,6 +200,9 @@ class StateSchema(SAMSchema):
     Resource = CharForeignProperty(Ref, required=False)
     End = BooleanProperty(required=False)
     Parameters = DictProperty(required=False)
+    ResultPath = CharForeignProperty(Ref, required=False)
+    OutputPath = CharForeignProperty(Ref, required=False)
+
 
     def to_dict(self):
         obj = remove_nulls(self._data.copy())

--- a/sammy/__init__.py
+++ b/sammy/__init__.py
@@ -263,6 +263,7 @@ class SQSEvent(EventSchema):
 
     Queue = CharForeignProperty(Ref, required=True)
     BatchSize = IntForeignProperty(Ref)
+    FunctionResponseTypes = ListProperty()
 
 
 class KinesisEvent(EventSchema):
@@ -364,6 +365,7 @@ class SQS(Resource):
     ReceiveMessageWaitTimeSeconds = IntForeignProperty(SAMSchema)
     VisibilityTimeout = IntForeignProperty(SAMSchema)
     QueueName = CharForeignProperty(Ref)
+    RedrivePolicy = DictProperty()
 
 
 class AbstractFunction(Resource):

--- a/sammy/__init__.py
+++ b/sammy/__init__.py
@@ -267,6 +267,12 @@ class SQSEvent(EventSchema):
     MaximumBatchingWindowInSeconds = IntegerProperty()
 
 
+class ScheduleEvent(EventSchema):
+    _event_type = 'Schedule'
+
+    Schedule = CharProperty()
+
+
 class KinesisEvent(EventSchema):
     _event_type = 'Kinesis'
 

--- a/sammy/__init__.py
+++ b/sammy/__init__.py
@@ -479,6 +479,9 @@ class SAM(SAMSchema):
     aws_template_format_version = '2010-09-09'
     transform = 'AWS::Serverless-2016-10-31'
     Description = CharProperty()
+    Conditions = DictProperty(required=False)
+    Globals = DictProperty(required=False)
+    Outputs = DictProperty(required=False)
     resources = ForeignInstanceListProperty(Resource)
     parameters = ForeignInstanceListProperty(Parameter)
     render_type = CharProperty(choices=RENDER_FORMATS, default_value='yaml')
@@ -544,12 +547,18 @@ class SAM(SAMSchema):
             template['Transform'] = self.transform
         if obj.get('Description'):
             template['Description'] = obj.get('Description')
+        if obj.get('Conditions'):
+            template['Conditions'] = obj.get('Conditions')
+        if obj.get('Globals'):
+            template['Globals'] = obj.get('Globals')
         if obj.get('parameters'):
             pl = [i.to_dict() for i in obj.get('parameters')]
             parameters = {i.get('name'): i.get('r') for i in pl}
             if len(parameters.keys()) > 0:
                 template['Parameters'] = parameters
         template['Resources'] = resources
+        if obj.get('Outputs'):
+            template['Outputs'] = obj.get('Outputs')
         return template
 
     def get_template_dict(self):

--- a/sammy/examples/layers.py
+++ b/sammy/examples/layers.py
@@ -1,0 +1,21 @@
+import sammy as sm
+
+
+sam = sm.SAM(Description='A hello world application.',render_type='yaml')
+
+bucket = sm.S3Bucket(name="TestBucket", BucketName="MyBucket")
+layer = sm.LayerVersion(name="TestLayer", ContentUri="ContentTest")
+bucket2 = sm.S3Bucket(name="ZTestBucket", BucketName="MyBucket")
+
+
+sam.add_resource(layer)
+
+sam.add_resource(bucket)
+sam.add_resource(bucket2)
+
+#sam.add_resource(
+#    sm.Function(name='HelloWorldFunction',
+#        Handler='sample.handler', Runtime='python3.6', CodeUri=sm.S3URI(
+#            Bucket=sm.Ref(Ref='Bucket'),Key=sm.Ref(Ref='CodeZipKey'))))
+
+print(sam.to_yaml())

--- a/setup.py
+++ b/setup.py
@@ -1,9 +1,13 @@
-from pip._internal.req import parse_requirements
+import pathlib
+import pkg_resources
 from setuptools import setup, find_packages
 
-
-install_reqs = parse_requirements('requirements.txt', session=False)
-
+with pathlib.Path('requirements.txt').open() as requirements_txt:
+    install_requires = [
+        str(requirement)
+        for requirement
+        in pkg_resources.parse_requirements(requirements_txt)
+    ]
 version = '0.4.2'
 
 setup(
@@ -25,7 +29,7 @@ setup(
     packages=find_packages(),
     url='https://github.com/capless/sammy',
     license='GNU General Public License v3.0',
-    install_requires=[str(ir.req) for ir in install_reqs],
+    install_requires=install_requires,
     include_package_data=True,
     zip_safe=False,
 )


### PR DESCRIPTION
Thank you very much for this code. I have found it really useful as a way to define a SAM template in Python rather than repetitive raw YAML.

I have updated it and wondered if you would like to merge? You should certainly test it against your existing projects first if so.

Added some AWS types to schema including State Machines and CloudFront.
Conditions, Globals, Outputs added to template.yaml.
Switched to a different YAML processor due to problems with quotations.
